### PR TITLE
Workaround for documentation not loading

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Reviewers for all PRs
+*	@JBSnippets
+
+# Reviewers for GitHub PRs
+.github/* @JBSnippets

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The node enables the addition of health capabilities, which can be adjusted by i
 - Signals are emitted based on behavior, set properties, and updates to health amounts.
 
 ## 💽 Supported Versions
-<img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=orange">
+<img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue">
 
 ## 📥 Installing the Plugin
 ### Install using Godot's AssetLib
@@ -46,4 +46,4 @@ After enabling this plugin, you can add the `Health` node as a child of another 
 [![Watch the video](https://github.com/JBSnippets/godot4-health/blob/main/assets/JBSnippets%20YT%20Thumbnail%203.png)](https://www.youtube.com/watch?v=CS524A5O90s)
 
 ## 📡 More Plugins!
-Head on over to my website at [https://plugins.jbsnippets.com](https://plugins.jbsnippets.com) to read more about this plugin and other plugins that I've been creating during my game development journey.
+Head on over to my website at [https://plugins.jbsnippets.com](https://plugins.jbsnippets.com) to read more about this plugin and other plugins that I've been creating during my game development journey in Godot.

--- a/addons/jbs_health_node/README.md
+++ b/addons/jbs_health_node/README.md
@@ -13,7 +13,7 @@ The node enables the addition of health capabilities, which can be adjusted by i
 - Signals are emitted based on behavior, set properties, and updates to health amounts.
 
 ## 💽 Supported Versions
-<img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=orange">
+<img src="https://img.shields.io/badge/Godot-v4.1.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.1.4-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.0-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.1-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.2.2-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue"> <img src="https://img.shields.io/badge/Godot-v4.3-%23478cbf?logo=godot-engine&logoColor=cyian&color=blue">
 
 ## 📥 Installing the Plugin
 ### Install using Godot's AssetLib
@@ -46,4 +46,4 @@ After enabling this plugin, you can add the `Health` node as a child of another 
 [![Watch the video](https://github.com/JBSnippets/godot4-health/blob/main/assets/JBSnippets%20YT%20Thumbnail%203.png)](https://www.youtube.com/watch?v=CS524A5O90s)
 
 ## 📡 More Plugins!
-Head on over to my website at [https://plugins.jbsnippets.com](https://plugins.jbsnippets.com) to read more about this plugin and other plugins that I've been creating during my game development journey.
+Head on over to my website at [https://plugins.jbsnippets.com](https://plugins.jbsnippets.com) to read more about this plugin and other plugins that I've been creating during my game development journey Godot.

--- a/addons/jbs_health_node/controls/jbs_growl_label.gd
+++ b/addons/jbs_health_node/controls/jbs_growl_label.gd
@@ -1,9 +1,17 @@
+## A simple health growl label component to show the amount of health changed.[br][br]
+## 
+## The label will float above the character.
+class_name HealthGrowlLabel
 extends Label
 
+## The floating speed of the label.
 @export var float_speed: Vector2 = Vector2(0, -60)
 
-func _process(delta):
+## Returns the object's class name, as a [String].
+func get_class_name() -> String: return "HealthGrowlLabel"
+
+func _process(delta) -> void:
 	position += float_speed * delta
 
-func _on_timer_timeout():
+func _on_timer_timeout() -> void:
 	queue_free()

--- a/addons/jbs_health_node/controls/jbs_health_growler.gd
+++ b/addons/jbs_health_node/controls/jbs_health_growler.gd
@@ -8,18 +8,24 @@ extends Control
 ## The packed scene label to use for growling. An example growl label is included this plugin named JBSGrowlLabel
 @export var growl_label: PackedScene
 
+## The name of the Marker 2D node set as reference position when creating the label.
+@export var marker_2d_name: String = "GrowlPosition"
+
 ## The damage color of the floating text
 @export var damage_color: Color = Color.RED
 
 ## The heal color of the floating text
 @export var heal_color: Color = Color.GREEN
 
-func _ready():
+## Returns the object's class name, as a [String].
+func get_class_name() -> String: return "HealthGrowler"
+
+func _ready() -> void:
 	var global_health = get_tree().root.get_node("/root/GlobalHealth")
 	if global_health: global_health.update.connect(_on_health_update)
 		
-func _on_health_update(body: Node, amount: int, health: int):
-	var growl_position = body.find_child("GrowlPosition")
+func _on_health_update(body: Node, amount: int, health: int) -> void:
+	var growl_position = body.find_child(marker_2d_name)
 	if !growl_position: return
 	var label: Label = growl_label.instantiate()
 	label.text = str(amount)

--- a/addons/jbs_health_node/jbs_health.gd
+++ b/addons/jbs_health_node/jbs_health.gd
@@ -105,8 +105,8 @@ var _change_timer: Timer
 var _pause_timer: Timer
 var _current_change_in_seconds: float = 0
 
-## Returns the object's class name, as a [String]. This function overrides the [Object]'s built-in function [method Object.get_class].
-func get_class() -> String: return "Health"
+## Returns the object's class name, as a [String].
+func get_class_name() -> String: return "Health"
 
 func _ready() -> void:
 	_create_show_timer()

--- a/addons/jbs_health_node/jbs_health_node.gd
+++ b/addons/jbs_health_node/jbs_health_node.gd
@@ -1,12 +1,37 @@
 @tool
 extends EditorPlugin
 
+# scripts
+const GLOBAL_HEALTH_SCRIPT = "res://addons/jbs_health_node/jbs_global_health.gd"
+const HEALTH_SCRIPT = "res://addons/jbs_health_node/jbs_health.gd"
+const HEALTH_GROWLER_SCRIPT = "res://addons/jbs_health_node/controls/jbs_health_growler.gd"
+
+# icons
+const HEALTH_ICON = "res://addons/jbs_health_node/jbs_health_node.png"
+const HEALTH_GROWLER_ICON = "res://addons/jbs_health_node/controls/jbs_health_growler.png"
+
+var script_dictionary: Dictionary = {
+	"GlobalHealth": GLOBAL_HEALTH_SCRIPT,
+	"Health" : HEALTH_SCRIPT,
+	"HealthGrowler": HEALTH_GROWLER_SCRIPT
+}
+
 func _enter_tree() -> void:
-	add_autoload_singleton("GlobalHealth", "res://addons/jbs_health_node/jbs_global_health.gd")
-	add_custom_type("Health", "Node", preload("res://addons/jbs_health_node/jbs_health.gd"), preload("res://addons/jbs_health_node/jbs_health_node.png"))
-	add_custom_type("HealthGrowler", "Control", preload("res://addons/jbs_health_node/controls/jbs_health_growler.gd"), preload("res://addons/jbs_health_node/controls/jbs_health_growler.png"))
+	add_autoload_singleton("GlobalHealth", GLOBAL_HEALTH_SCRIPT)
+	add_custom_type("Health", "Node", preload(HEALTH_SCRIPT), preload(HEALTH_ICON))
+	add_custom_type("HealthGrowler", "Control", preload(HEALTH_GROWLER_SCRIPT), preload(HEALTH_GROWLER_ICON))
+	
+	_reload_scripts()
 	
 func _exit_tree() -> void:
 	remove_custom_type("HealthGrowler")
 	remove_custom_type("Health")
 	remove_autoload_singleton("GlobalHealth")
+
+# Workaround to save script and force reload/refresh of script plugin documentations
+func _reload_scripts() -> void:
+	for key in script_dictionary.keys():
+		var script_path = script_dictionary.get(key)
+		var script = ResourceLoader.load(script_path)
+		if script:
+			ResourceSaver.save(script, script_path)

--- a/addons/jbs_health_node/plugin.cfg
+++ b/addons/jbs_health_node/plugin.cfg
@@ -3,5 +3,5 @@
 name="Health"
 description="A custom node designed to store values, update them, and emit signals related to health."
 author="JBSnippets"
-version="0.1.1"
+version="0.1.2"
 script="jbs_health_node.gd"

--- a/examples/heart_1.gd
+++ b/examples/heart_1.gd
@@ -2,6 +2,6 @@ extends Area2D
 
 @export var life: int = 20
 
-func _on_body_entered(body):
+func _on_body_entered(body) -> void:
 	if body.has_method("health_update"):
 		body.health_update(life)

--- a/examples/player.gd
+++ b/examples/player.gd
@@ -10,10 +10,10 @@ const JUMP_VELOCITY = -400.0
 var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
 var dead: bool =false
 
-func _ready():
+func _ready() -> void:
 	animation_player.play("idle")
 
-func _physics_process(delta):
+func _physics_process(delta) -> void:
 	# Add the gravity
 	if not is_on_floor():
 		velocity.y += gravity * delta
@@ -45,13 +45,13 @@ func _physics_process(delta):
 
 	move_and_slide()
 
-func health_update(amount: int):
+func health_update(amount: float) -> void:
 	health.update_amount(amount)
 
-func _on_health_death():
+func _on_health_death() -> void:
 	dead = true
 	animation_player.play("dead")
 
-func _on_health_revive(_amount, _health):
+func _on_health_revive(_amount, _health) -> void:
 	dead = false
 	animation_player.play("revive")

--- a/examples/spike_1.gd
+++ b/examples/spike_1.gd
@@ -2,6 +2,6 @@ extends Area2D
 
 @export var damage: int = -10
 
-func _on_body_entered(body):
+func _on_body_entered(body) -> void:
 	if body.has_method("health_update"):
 		body.health_update(damage)

--- a/examples/ui_layer.gd
+++ b/examples/ui_layer.gd
@@ -2,10 +2,10 @@ extends CanvasLayer
 
 var player
 
-func _ready():
+func _ready() -> void:
 	player = get_parent().get_node("Player")
 
-func _on_revive_pressed():
+func _on_revive_pressed() -> void:
 	if player and player.health.amount <= 0:
 		player.health_update(30)
 		print("I'm alive!")


### PR DESCRIPTION
## Description:
Workaround for documentation not loading

## Related Issues:
- Issue #5  

## Change Details:
- fixes #5 
- added ~ more 4.3 standard updates.
- added ~ mark_2d_name variable to HealthGrowler.
- updated ~ EditorPlugin script to implement a "reload scripts" function and work around documentation not loading.
- updated ~ get_class() function to get_class_name() function.
- updated ~ README updates.
- updated ~ version to 0.1.2